### PR TITLE
SENSU-747 - Convention based use of /hostproc and /hostsys to allow reading of system stats when run in a container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 
  The MIT License (MIT)
 
- Copyright (c) 2015 ThePlatform for Media
+ Copyright (c) 2015-16 Comcast Technology Solutions
 
      Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Linux process.  Metrics include information on:
 linux_stats was written specifically targeting Centos 5 & 6.  It's likely
 to work on other platforms as well, but those configurations are untested.
 
+## Docker Support
+We've added convention-based support for linux_stats to collect host information while running within a Docker
+container.  This is accomplished by mounting the host's /proc and /sys to /hostproc and /hostsys within the container.
+
 ### Note
 Mac OS X is not supported.  linux_stats gets its data by inspecting the
 /proc filesystem, which does not exist on macs.

--- a/bin/os_stats
+++ b/bin/os_stats
@@ -2,7 +2,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/process_stats
+++ b/bin/process_stats
@@ -2,7 +2,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats.rb
+++ b/lib/linux_stats.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os/cpu_stat.rb
+++ b/lib/linux_stats/os/cpu_stat.rb
@@ -33,11 +33,17 @@ module LinuxStats::OS::CPU
     STEAL = 8
   end
 
-  DATA_FILE = '/proc/stat'
+  PROC_DIRECTORY_DEFAULT = '/proc'
+  DATA_FILE = '/stat'
 
   class Reporter
-    def initialize(data = nil)
+    def initialize(data = nil, data_directory = PROC_DIRECTORY_DEFAULT)
+      set_data_paths data_directory
       set_stats data
+    end
+
+    def set_data_paths(data_directory = nil)
+      @proc_file_source = "#{data_directory}#{DATA_FILE}"
     end
 
     def report(elapsed_time=nil, data=nil)
@@ -62,7 +68,7 @@ module LinuxStats::OS::CPU
     end
 
     def set_stats(proc_stat_data = nil)
-      proc_stat_data = File.read(DATA_FILE) unless proc_stat_data
+      proc_stat_data = File.read(@proc_file_source) unless proc_stat_data
       @current_timestamp = Time.now
       @current_stats = {}
       @current_stats[:cpu] = {}

--- a/lib/linux_stats/os/cpu_stat.rb
+++ b/lib/linux_stats/os/cpu_stat.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os/cpu_stat.rb
+++ b/lib/linux_stats/os/cpu_stat.rb
@@ -40,7 +40,6 @@ module LinuxStats::OS::CPU
     def initialize(data = nil, data_directory = PROC_DIRECTORY_DEFAULT)
       set_data_paths data_directory
       set_stats data
-      puts "PROC FILE SOURCE = #{@proc_file_source}"
     end
 
     def set_data_paths(data_directory = nil)

--- a/lib/linux_stats/os/cpu_stat.rb
+++ b/lib/linux_stats/os/cpu_stat.rb
@@ -40,6 +40,7 @@ module LinuxStats::OS::CPU
     def initialize(data = nil, data_directory = PROC_DIRECTORY_DEFAULT)
       set_data_paths data_directory
       set_stats data
+      puts "PROC FILE SOURCE = #{@proc_file_source}"
     end
 
     def set_data_paths(data_directory = nil)

--- a/lib/linux_stats/os/proc_loadavg.rb
+++ b/lib/linux_stats/os/proc_loadavg.rb
@@ -32,7 +32,6 @@ module LinuxStats::OS::Loadavg
   class Reporter
     def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
       set_data_paths data_directory
-      puts "LOADAVG FILE SOURCE = #{@proc_file_source}"
     end
 
     def set_data_paths(data_directory = nil)

--- a/lib/linux_stats/os/proc_loadavg.rb
+++ b/lib/linux_stats/os/proc_loadavg.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os/proc_loadavg.rb
+++ b/lib/linux_stats/os/proc_loadavg.rb
@@ -26,13 +26,22 @@ require 'linux_stats'
 # data in the /proc/loadavg file
 
 module LinuxStats::OS::Loadavg
-  DATA_FILE = '/proc/loadavg'
+  PROC_DIRECTORY_DEFAULT = '/proc'
+  DATA_FILE = '/loadavg'
 
   class Reporter
+    def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
+      set_data_paths data_directory
+    end
+
+    def set_data_paths(data_directory = nil)
+      @proc_file_source = "#{data_directory}#{DATA_FILE}"
+    end
+
     def report(data = nil)
       # execution time: 0.12 ms  [LOW]
       load_report = {}
-      data = File.read(DATA_FILE) unless data
+      data = File.read(@proc_file_source) unless data
       words = data.split
       load_report[:one] = words[0].to_f
       load_report[:five] = words[1].to_f

--- a/lib/linux_stats/os/proc_loadavg.rb
+++ b/lib/linux_stats/os/proc_loadavg.rb
@@ -32,6 +32,7 @@ module LinuxStats::OS::Loadavg
   class Reporter
     def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
       set_data_paths data_directory
+      puts "LOADAVG FILE SOURCE = #{@proc_file_source}"
     end
 
     def set_data_paths(data_directory = nil)

--- a/lib/linux_stats/os/proc_meminfo.rb
+++ b/lib/linux_stats/os/proc_meminfo.rb
@@ -23,7 +23,8 @@
 require 'linux_stats'
 
 module LinuxStats::OS::Meminfo
-  DATA_FILE = '/proc/meminfo'
+  PROC_DIRECTORY_DEFAULT = '/proc'
+  DATA_FILE = '/meminfo'
   MEM_FREE = 'MemFree'
   MEM_TOTAL = 'MemTotal'
   PAGE_CACHE = 'Cached'
@@ -31,10 +32,18 @@ module LinuxStats::OS::Meminfo
   SWAP_TOTAL = 'SwapTotal'
 
   class Reporter
+    def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
+      set_data_paths data_directory
+      puts "MEMINFO FILE SOURCE = #{@proc_file_source}"
+    end
 
+    def set_data_paths(data_directory = nil)
+      @proc_file_source = "#{data_directory}#{DATA_FILE}"
+    end 
+   
     def report(data = nil)
       mem_report = {}
-      data = File.read(DATA_FILE) unless data
+      data = File.read(@proc_file_source) unless data
       data.each_line do |line|
         if line =~ /^#{MEM_TOTAL}/
           # puts line.split[1], line.split[1].to_i

--- a/lib/linux_stats/os/proc_meminfo.rb
+++ b/lib/linux_stats/os/proc_meminfo.rb
@@ -34,7 +34,6 @@ module LinuxStats::OS::Meminfo
   class Reporter
     def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
       set_data_paths data_directory
-      puts "MEMINFO FILE SOURCE = #{@proc_file_source}"
     end
 
     def set_data_paths(data_directory = nil)

--- a/lib/linux_stats/os/proc_meminfo.rb
+++ b/lib/linux_stats/os/proc_meminfo.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os/proc_mounts.rb
+++ b/lib/linux_stats/os/proc_mounts.rb
@@ -46,7 +46,6 @@ module LinuxStats::OS::Mounts
 
     def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
       set_data_paths data_directory
-      puts "MOUNTS PATH = #{@proc_data_source}"
       @blocks_per_kilobyte = 4 # TODO: calculate from info in /proc?  Where?
       @mounted_partitions = mounts
     end

--- a/lib/linux_stats/os/proc_mounts.rb
+++ b/lib/linux_stats/os/proc_mounts.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os/proc_mounts.rb
+++ b/lib/linux_stats/os/proc_mounts.rb
@@ -33,9 +33,10 @@ module LinuxStats::OS::Mounts
       '^\/cgroup',
       '\['
   ]
+  PROC_DIRECTORY_DEFAULT = '/proc'
 
   module DataFile
-    MOUNTS = '/proc/mounts'
+    MOUNTS_PATH = '/mounts'
   end
 
   class Reporter
@@ -43,9 +44,15 @@ module LinuxStats::OS::Mounts
     attr_accessor :blocks_per_kilobyte,
                   :mounted_partitions
 
-    def initialize
+    def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
+      set_data_paths data_directory
+      puts "MOUNTS PATH = #{@proc_data_source}"
       @blocks_per_kilobyte = 4 # TODO: calculate from info in /proc?  Where?
       @mounted_partitions = mounts
+    end
+
+    def set_data_paths(data_directory = nil)
+      @proc_data_source = "#{data_directory}#{DataFile::MOUNTS_PATH}"
     end
 
     def report
@@ -77,7 +84,7 @@ module LinuxStats::OS::Mounts
 
     def mounts
       mount_list = []
-      IO.readlines(DataFile::MOUNTS).each do |line|
+      IO.readlines(@proc_data_source).each do |line|
         mount = line.split[1]
         next if IGNORE_PARTITIONS.include? mount
         mount_list.push line.split[1].strip

--- a/lib/linux_stats/os/proc_net_dev.rb
+++ b/lib/linux_stats/os/proc_net_dev.rb
@@ -59,7 +59,6 @@ module LinuxStats::OS::NetBandwidth
 
     def initialize(data = nil,data_directory = PROC_DIRECTORY_DEFAULT)
       set_data_paths data_directory
-      puts "NETDEV FILE SOURCE = #{@proc_file_source}"
       set_stats data
     end
 

--- a/lib/linux_stats/os/proc_net_dev.rb
+++ b/lib/linux_stats/os/proc_net_dev.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os/proc_net_dev.rb
+++ b/lib/linux_stats/os/proc_net_dev.rb
@@ -24,7 +24,8 @@
 require 'linux_stats'
 
 module LinuxStats::OS::NetBandwidth
-  DATA_FILE = '/proc/net/dev'
+  PROC_DIRECTORY_DEFAULT = '/proc'
+  DATA_FILE = '/net/dev'
 
   module Column
     BYTES_RX = 0
@@ -56,8 +57,14 @@ module LinuxStats::OS::NetBandwidth
   class Reporter
     attr_accessor :current_stats, :current_timestamp
 
-    def initialize(data = nil)
+    def initialize(data = nil,data_directory = PROC_DIRECTORY_DEFAULT)
+      set_data_paths data_directory
+      puts "NETDEV FILE SOURCE = #{@proc_file_source}"
       set_stats data
+    end
+
+    def set_data_paths(data_directory = nil)
+      @proc_file_source = "#{data_directory}#{DATA_FILE}"
     end
 
     def report(elapsed_time = nil, data = nil)
@@ -83,7 +90,7 @@ module LinuxStats::OS::NetBandwidth
     private
 
     def set_stats(bandwidth_data = nil)
-      bandwidth_data = File.read(DATA_FILE) unless bandwidth_data
+      bandwidth_data = File.read(@proc_file_source) unless bandwidth_data
       @current_timestamp = Time.now
       @current_stats = {}
       bandwidth_data.each_line do |line|

--- a/lib/linux_stats/os/proc_net_sockstat.rb
+++ b/lib/linux_stats/os/proc_net_sockstat.rb
@@ -37,7 +37,6 @@ module LinuxStats::OS::NetSocket
   class Reporter
     def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
       set_data_paths data_directory
-      puts "NETSOCKSTATS FILE SOURCE = #{@proc_file_source}"
     end
 
     def set_data_paths(data_directory = nil)

--- a/lib/linux_stats/os/proc_net_sockstat.rb
+++ b/lib/linux_stats/os/proc_net_sockstat.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os/proc_net_sockstat.rb
+++ b/lib/linux_stats/os/proc_net_sockstat.rb
@@ -26,7 +26,8 @@ require 'linux_stats'
 # data in the /proc/loadavg file
 
 module LinuxStats::OS::NetSocket
-  DATA_FILE = '/proc/net/sockstat'
+  PROC_DIRECTORY_DEFAULT = '/proc'
+  DATA_FILE = '/net/sockstat'
 
   module Column
     OPEN_CONNECTIONS = 2
@@ -34,9 +35,18 @@ module LinuxStats::OS::NetSocket
   end
 
   class Reporter
+    def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
+      set_data_paths data_directory
+      puts "NETSOCKSTATS FILE SOURCE = #{@proc_file_source}"
+    end
+
+    def set_data_paths(data_directory = nil)
+      @proc_file_source = "#{data_directory}#{DATA_FILE}"
+    end
+
     def report(data = nil)
       ret = {}
-      data = File.read(DATA_FILE) unless data
+      data = File.read(@proc_file_source) unless data
       data.each_line do |line|
         next unless line =~ /^TCP/
         words = line.split()

--- a/lib/linux_stats/os/proc_sys_file.rb
+++ b/lib/linux_stats/os/proc_sys_file.rb
@@ -34,7 +34,6 @@ module LinuxStats::OS::FileDescriptor
     # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/5/html/Tuning_and_Optimizing_Red_Hat_Enterprise_Linux_for_Oracle_9i_and_10g_Databases/chap-Oracle_9i_and_10g_Tuning_Guide-Setting_File_Handles.html
     def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
       set_data_paths data_directory
-      puts "FILEDESC FILE SOURCE = #{@proc_file_source}"
     end
 
     def set_data_paths(data_directory = nil)

--- a/lib/linux_stats/os/proc_sys_file.rb
+++ b/lib/linux_stats/os/proc_sys_file.rb
@@ -26,17 +26,25 @@ require 'linux_stats'
 # /proc/sys/fs/file-nr
 
 module LinuxStats::OS::FileDescriptor
-
-  DATA_FILE = '/proc/sys/fs/file-nr'
+  PROC_DIRECTORY_DEFAULT = '/proc'
+  DATA_FILE = '/sys/fs/file-nr'
 
   class Reporter
     # for description of file-nr info, see
     # https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/5/html/Tuning_and_Optimizing_Red_Hat_Enterprise_Linux_for_Oracle_9i_and_10g_Databases/chap-Oracle_9i_and_10g_Tuning_Guide-Setting_File_Handles.html
+    def initialize(data_directory = PROC_DIRECTORY_DEFAULT)
+      set_data_paths data_directory
+      puts "FILEDESC FILE SOURCE = #{@proc_file_source}"
+    end
+
+    def set_data_paths(data_directory = nil)
+      @proc_file_source = "#{data_directory}#{DATA_FILE}"
+    end
 
     def report(data = nil)
       # execution time: 0.1 ms  [LOW]
       file_descriptors = {}
-      data = File.read(DATA_FILE) unless data
+      data = File.read(@proc_file_source) unless data
       words = data.split
       allocated = words[0].to_i
       available = words[1].to_i

--- a/lib/linux_stats/os/proc_sys_file.rb
+++ b/lib/linux_stats/os/proc_sys_file.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os/proc_vmstat.rb
+++ b/lib/linux_stats/os/proc_vmstat.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os/proc_vmstat.rb
+++ b/lib/linux_stats/os/proc_vmstat.rb
@@ -39,7 +39,6 @@ module LinuxStats::OS::Vmstat
 
     def initialize(data = nil, data_directory = PROC_DIRECTORY_DEFAULT)
       set_data_paths data_directory
-      puts "VMSTAT FILE SOURCE = #{@proc_file_source}"
       set_stats data
     end
 

--- a/lib/linux_stats/os/proc_vmstat.rb
+++ b/lib/linux_stats/os/proc_vmstat.rb
@@ -30,14 +30,21 @@ module LinuxStats::OS::Vmstat
     SWAP_IN = '^pswpin'
     SWAP_OUT = '^pswpout'
   end
-
-  DATA_FILE = '/proc/vmstat'
+  
+  PROC_DIRECTORY_DEFAULT = '/proc'
+  DATA_FILE = '/vmstat'
 
   class Reporter
     attr_accessor :current_stats, :current_timestamp
 
-    def initialize(data = nil)
+    def initialize(data = nil, data_directory = PROC_DIRECTORY_DEFAULT)
+      set_data_paths data_directory
+      puts "VMSTAT FILE SOURCE = #{@proc_file_source}"
       set_stats data
+    end
+
+    def set_data_paths(data_directory = nil)
+      @proc_file_source = "#{data_directory}#{DATA_FILE}"
     end
 
     def report(elapsed_time = nil, data = nil)
@@ -61,7 +68,7 @@ module LinuxStats::OS::Vmstat
 
     # gets a snapshot of the swap and page info in /proc/vmstat
     def set_stats(vmstat_data = nil)
-      vmstat_data = File.read(DATA_FILE) unless vmstat_data
+      vmstat_data = File.read(@proc_file_source) unless vmstat_data
       @current_timestamp = Time.now
       @current_stats = {}
       vmstat_data.each_line do |line|

--- a/lib/linux_stats/os/sys_block_stat.rb
+++ b/lib/linux_stats/os/sys_block_stat.rb
@@ -46,7 +46,9 @@ module LinuxStats::OS::BlockIO
   end
 
   class Reporter
-    def initialize(_data = nil, proc_data_directory = PROC_DIRECTORY_DEFAULT, sys_data_directory = SYS_DIRECTORY_DEFAULT)
+    def initialize(_data = nil, 
+        proc_data_directory = PROC_DIRECTORY_DEFAULT, 
+        sys_data_directory = SYS_DIRECTORY_DEFAULT)
       set_data_paths(proc_data_directory,sys_data_directory)
 
       @bytes_per_sector = sector_size

--- a/lib/linux_stats/os/sys_block_stat.rb
+++ b/lib/linux_stats/os/sys_block_stat.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os/sys_block_stat.rb
+++ b/lib/linux_stats/os/sys_block_stat.rb
@@ -47,7 +47,6 @@ module LinuxStats::OS::BlockIO
 
   class Reporter
     def initialize(_data = nil, proc_data_directory = PROC_DIRECTORY_DEFAULT, sys_data_directory = SYS_DIRECTORY_DEFAULT)
-      puts "Does I initialize?"
       set_data_paths(proc_data_directory,sys_data_directory)
       puts "BLOCKIO FILE SOURCES = #{@proc_cpuinfo_source},#{@proc_diskstats_source},#{@sys_sectorsize_source}"
 

--- a/lib/linux_stats/os/sys_block_stat.rb
+++ b/lib/linux_stats/os/sys_block_stat.rb
@@ -51,7 +51,7 @@ module LinuxStats::OS::BlockIO
       set_data_paths(proc_data_directory,sys_data_directory)
       puts "BLOCKIO FILE SOURCES = #{@proc_cpuinfo_source},#{@proc_diskstats_source},#{@sys_sectorsize_source}"
 
-      @bytes_per_sector = self.sector_size
+      @bytes_per_sector = sector_size
       @ignore_disks = [
           '^dm-[0-9]',
           '^fd[0-9]',
@@ -60,8 +60,8 @@ module LinuxStats::OS::BlockIO
           '^sr',
           '^sd.*[0-9]'
       ]
-      @num_cpu = self.cpuinfo
-      @watched_disks_list = self.watched_disks
+      @num_cpu = cpuinfo
+      @watched_disks_list = watched_disks
       set_stats
     end
     
@@ -72,7 +72,7 @@ module LinuxStats::OS::BlockIO
       @sys_sectorsize_source = "#{sys_data_directory}#{DataFile::SECTOR_SIZE}"
     end
 
-    def self.cpuinfo
+    def cpuinfo
       ret = 0
       IO.readlines(@proc_cpuinfo_source).each do |line|
         ret += 1 if line =~ /^processor/
@@ -80,7 +80,7 @@ module LinuxStats::OS::BlockIO
       ret
     end
 
-    def self.sector_size
+    def sector_size
       begin
         return File.read(@sys_sectorsize_source).strip.to_i
       rescue
@@ -89,7 +89,7 @@ module LinuxStats::OS::BlockIO
       end
     end
 
-    def self.watched_disks(data = nil)
+    def watched_disks(data = nil)
       disk_list = []
       data = File.read(@proc_diskstats_source) unless data
       data.each_line do |line|

--- a/lib/linux_stats/os/sys_block_stat.rb
+++ b/lib/linux_stats/os/sys_block_stat.rb
@@ -51,7 +51,7 @@ module LinuxStats::OS::BlockIO
       set_data_paths(proc_data_directory,sys_data_directory)
       puts "BLOCKIO FILE SOURCES = #{@proc_cpuinfo_source},#{@proc_diskstats_source},#{@sys_sectorsize_source}"
 
-      @bytes_per_sector = sector_size
+      @bytes_per_sector = self.sector_size
       @ignore_disks = [
           '^dm-[0-9]',
           '^fd[0-9]',
@@ -60,8 +60,8 @@ module LinuxStats::OS::BlockIO
           '^sr',
           '^sd.*[0-9]'
       ]
-      @num_cpu = cpuinfo
-      @watched_disks_list = watched_disks
+      @num_cpu = self.cpuinfo
+      @watched_disks_list = self.watched_disks
       set_stats
     end
     

--- a/lib/linux_stats/os/sys_block_stat.rb
+++ b/lib/linux_stats/os/sys_block_stat.rb
@@ -48,7 +48,6 @@ module LinuxStats::OS::BlockIO
   class Reporter
     def initialize(_data = nil, proc_data_directory = PROC_DIRECTORY_DEFAULT, sys_data_directory = SYS_DIRECTORY_DEFAULT)
       set_data_paths(proc_data_directory,sys_data_directory)
-      puts "BLOCKIO FILE SOURCES = #{@proc_cpuinfo_source},#{@proc_diskstats_source},#{@sys_sectorsize_source}"
 
       @bytes_per_sector = sector_size
       @ignore_disks = [

--- a/lib/linux_stats/os_stats.rb
+++ b/lib/linux_stats/os_stats.rb
@@ -44,15 +44,15 @@ module LinuxStats::OS
       set_data_directories
       puts "PROC DIRECTORY = #{@proc_directory}"
       puts "SYS DIRECTORY = #{@sys_directory}"
-      @cpu_reporter = CPU::Reporter.new(nil,@proc_directory)
-      @disk_io_reporter = BlockIO::Reporter.new
-      @filedescriptor_reporter = FileDescriptor::Reporter.new
+      @cpu_reporter = CPU::Reporter.new(nil, @proc_directory)
+      @disk_io_reporter = BlockIO::Reporter.new(nil, @proc_directory, @sys_directory)
+      @filedescriptor_reporter = FileDescriptor::Reporter.new(@proc_directory)
       @loadavg_reporter = Loadavg::Reporter.new(@proc_directory)
       @mem_reporter = Meminfo::Reporter.new(@proc_directory)
       @mounts_reporter = Mounts::Reporter.new(@proc_directory)
       @netbandwidth_reporter = NetBandwidth::Reporter.new(nil,@proc_directory)
-      @netsocket_reporter = NetSocket::Reporter.new
-      @vmstat_reporter = Vmstat::Reporter.new
+      @netsocket_reporter = NetSocket::Reporter.new(@proc_directory)
+      @vmstat_reporter = Vmstat::Reporter.new(nil, @proc_directory)
     end
 
     def set_data_directories

--- a/lib/linux_stats/os_stats.rb
+++ b/lib/linux_stats/os_stats.rb
@@ -42,8 +42,6 @@ module LinuxStats::OS
 
     def initialize
       set_data_directories
-      puts "PROC DIRECTORY = #{@proc_directory}"
-      puts "SYS DIRECTORY = #{@sys_directory}"
       @cpu_reporter = CPU::Reporter.new(nil, @proc_directory)
       @disk_io_reporter = BlockIO::Reporter.new(nil, @proc_directory, @sys_directory)
       @filedescriptor_reporter = FileDescriptor::Reporter.new(@proc_directory)

--- a/lib/linux_stats/os_stats.rb
+++ b/lib/linux_stats/os_stats.rb
@@ -27,7 +27,9 @@ module LinuxStats::OS
 
   class Reporter
 
-    attr_reader :cpu_reporter,
+    attr_reader :proc_directory,
+                :sys_directory,
+                :cpu_reporter,
                 :disk_io_reporter,
                 :filedescriptor_reporter,
                 :loadavg_reporter,
@@ -40,8 +42,9 @@ module LinuxStats::OS
     PROC_DIRECTORY_MOUNTED = '/hostproc'
     SYS_DIRECTORY_MOUNTED = '/hostsys'
 
-    def initialize
-      set_data_directories
+    def initialize(use_test_paths = false)
+      set_data_directories use_test_paths
+      return if use_test_paths
       @cpu_reporter = CPU::Reporter.new(nil, @proc_directory)
       @disk_io_reporter = BlockIO::Reporter.new(nil, @proc_directory, @sys_directory)
       @filedescriptor_reporter = FileDescriptor::Reporter.new(@proc_directory)
@@ -53,13 +56,13 @@ module LinuxStats::OS
       @vmstat_reporter = Vmstat::Reporter.new(nil, @proc_directory)
     end
 
-    def set_data_directories
+    def set_data_directories(use_test_paths = false)
       @proc_directory = '/proc'
       @sys_directory = '/sys'
-      if Dir.exists?(PROC_DIRECTORY_MOUNTED)
+      if Dir.exists?(PROC_DIRECTORY_MOUNTED) || use_test_paths
         @proc_directory = PROC_DIRECTORY_MOUNTED
       end
-      if Dir.exists?(SYS_DIRECTORY_MOUNTED)
+      if Dir.exists?(SYS_DIRECTORY_MOUNTED) || use_test_paths
         @sys_directory = SYS_DIRECTORY_MOUNTED
       end
     end

--- a/lib/linux_stats/os_stats.rb
+++ b/lib/linux_stats/os_stats.rb
@@ -48,9 +48,9 @@ module LinuxStats::OS
       @disk_io_reporter = BlockIO::Reporter.new
       @filedescriptor_reporter = FileDescriptor::Reporter.new
       @loadavg_reporter = Loadavg::Reporter.new(@proc_directory)
-      @mem_reporter = Meminfo::Reporter.new
-      @mounts_reporter = Mounts::Reporter.new
-      @netbandwidth_reporter = NetBandwidth::Reporter.new
+      @mem_reporter = Meminfo::Reporter.new(@proc_directory)
+      @mounts_reporter = Mounts::Reporter.new(@proc_directory)
+      @netbandwidth_reporter = NetBandwidth::Reporter.new(nil,@proc_directory)
       @netsocket_reporter = NetSocket::Reporter.new
       @vmstat_reporter = Vmstat::Reporter.new
     end

--- a/lib/linux_stats/os_stats.rb
+++ b/lib/linux_stats/os_stats.rb
@@ -37,6 +37,12 @@ module LinuxStats::OS
                 :netsocket_reporter,
                 :vmstat_reporter
 
+    PROC_DIRECTORY_MOUNTED = '/hostproc'
+    SYS_DIRECTORY_MOUNTED = '/hostsys'
+
+    @proc_directory = '/proc'
+    @sys_directory = '/sys'
+
     def initialize
       @cpu_reporter = CPU::Reporter.new
       @disk_io_reporter = BlockIO::Reporter.new
@@ -47,6 +53,15 @@ module LinuxStats::OS
       @netbandwidth_reporter = NetBandwidth::Reporter.new
       @netsocket_reporter = NetSocket::Reporter.new
       @vmstat_reporter = Vmstat::Reporter.new
+    end
+
+    def set_data_directories
+      if Dir.exists(PROC_DIRECTORY_MOUNTED)
+        @proc_directory = PROC_DIRECTORY_MOUNTED
+      end
+      if Dir.exists?(SYS_DIRECTORY_MOUNTED)
+        @sys_directory = SYS_DIRECTORY_MOUNTED
+      end
     end
 
     def report

--- a/lib/linux_stats/os_stats.rb
+++ b/lib/linux_stats/os_stats.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/os_stats.rb
+++ b/lib/linux_stats/os_stats.rb
@@ -40,14 +40,14 @@ module LinuxStats::OS
     PROC_DIRECTORY_MOUNTED = '/hostproc'
     SYS_DIRECTORY_MOUNTED = '/hostsys'
 
-    @proc_directory = '/proc'
-    @sys_directory = '/sys'
-
     def initialize
-      @cpu_reporter = CPU::Reporter.new
+      set_data_directories
+      puts "PROC DIRECTORY = #{@proc_directory}"
+      puts "SYS DIRECTORY = #{@sys_directory}"
+      @cpu_reporter = CPU::Reporter.new(nil,@proc_directory)
       @disk_io_reporter = BlockIO::Reporter.new
       @filedescriptor_reporter = FileDescriptor::Reporter.new
-      @loadavg_reporter = Loadavg::Reporter.new
+      @loadavg_reporter = Loadavg::Reporter.new(@proc_directory)
       @mem_reporter = Meminfo::Reporter.new
       @mounts_reporter = Mounts::Reporter.new
       @netbandwidth_reporter = NetBandwidth::Reporter.new
@@ -56,7 +56,9 @@ module LinuxStats::OS
     end
 
     def set_data_directories
-      if Dir.exists(PROC_DIRECTORY_MOUNTED)
+      @proc_directory = '/proc'
+      @sys_directory = '/sys'
+      if Dir.exists?(PROC_DIRECTORY_MOUNTED)
         @proc_directory = PROC_DIRECTORY_MOUNTED
       end
       if Dir.exists?(SYS_DIRECTORY_MOUNTED)

--- a/lib/linux_stats/process/process_stat.rb
+++ b/lib/linux_stats/process/process_stat.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/process_stats.rb
+++ b/lib/linux_stats/process_stats.rb
@@ -45,8 +45,17 @@ module LinuxStats::Process
 
     attr_reader :report_map
 
+    PROC_DIRECTORY_MOUNTED = '/hostproc'
+
     def initialize
       @report_map = {}
+    end
+
+    def set_proc_directory
+      @proc_directory = '/proc'
+      if Dir.exists?(PROC_DIRECTORY_MOUNTED)
+        @proc_directory = PROC_DIRECTORY_MOUNTED
+      end
     end
 
     def report(friendly_name, regex)
@@ -66,7 +75,8 @@ module LinuxStats::Process
     def pids(cmd)
       # execution time: 7ms  [VERY HIGH]
       pid_list = []
-      Dir['/proc/[0-9]*/cmdline'].each do |p|
+      pid_dir_regex = "#{@proc_directory}/[0-9]*/cmdline"
+      Dir[pid_dir_regex].each do |p|
         begin
           pid_list.push(p.split('/')[PID_INDEX]) if File.read(p).match(cmd)
         rescue

--- a/lib/linux_stats/process_stats.rb
+++ b/lib/linux_stats/process_stats.rb
@@ -43,18 +43,20 @@ module LinuxStats::Process
 
   class Reporter
 
-    attr_reader :report_map
+    attr_reader :proc_directory,
+                :report_map
 
     PROC_DIRECTORY_MOUNTED = '/hostproc'
 
-    def initialize
-      set_proc_directory
+    def initialize(use_test_paths = false)
+      set_proc_directory use_test_paths
+      return if use_test_paths
       @report_map = {}
     end
 
-    def set_proc_directory
+    def set_proc_directory(use_test_paths = false)
       @proc_directory = '/proc'
-      if Dir.exists?(PROC_DIRECTORY_MOUNTED)
+      if Dir.exists?(PROC_DIRECTORY_MOUNTED) || use_test_paths
         @proc_directory = PROC_DIRECTORY_MOUNTED
       end
     end

--- a/lib/linux_stats/process_stats.rb
+++ b/lib/linux_stats/process_stats.rb
@@ -48,6 +48,7 @@ module LinuxStats::Process
     PROC_DIRECTORY_MOUNTED = '/hostproc'
 
     def initialize
+      set_proc_directory
       @report_map = {}
     end
 

--- a/lib/linux_stats/process_stats.rb
+++ b/lib/linux_stats/process_stats.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/version.rb
+++ b/lib/linux_stats/version.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/lib/linux_stats/version.rb
+++ b/lib/linux_stats/version.rb
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 
 module LinuxStats
-  VERSION = '0.3.14'
+  VERSION = '0.4.0'
 end
 
 module LinuxStats

--- a/linux_stats.gemspec
+++ b/linux_stats.gemspec
@@ -28,11 +28,11 @@ require 'linux_stats/version'
 Gem::Specification.new do |spec|
   spec.name          = 'linux_stats'
   spec.version       = LinuxStats::VERSION
-  spec.authors       = ['Travis Bear']
-  spec.email         = ['travis.bear@comcast.com']
+  spec.authors       = ['Continuous Delivery Tribe - Comcast Technology Solutions']
+  spec.email         = ['tribecd@comcast.com']
   spec.summary       = 'Lightweight OS stats extracted from /proc'
   spec.description   = 'Inspects the state of the system, reports stats'
-  spec.homepage      = 'https://github.com/thePlatform/linux_stats' # TODO: point me at github
+  spec.homepage      = 'https://github.com/thePlatform/linux_stats'
   spec.license       = 'All rights reserved'
 
   spec.files         = Dir['lib/**/*.rb'] +

--- a/linux_stats.gemspec
+++ b/linux_stats.gemspec
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,10 +29,10 @@ Gem::Specification.new do |spec|
   spec.name          = 'linux_stats'
   spec.version       = LinuxStats::VERSION
   spec.authors       = ['Travis Bear']
-  spec.email         = ['travis.bear@theplatform.com']
+  spec.email         = ['travis.bear@comcast.com']
   spec.summary       = 'Lightweight OS stats extracted from /proc'
   spec.description   = 'Inspects the state of the system, reports stats'
-  spec.homepage      = 'http://theplatform.com' # TODO: point me at github
+  spec.homepage      = 'https://github.com/thePlatform/linux_stats' # TODO: point me at github
   spec.license       = 'All rights reserved'
 
   spec.files         = Dir['lib/**/*.rb'] +

--- a/spec/alternate_path_spec.rb
+++ b/spec/alternate_path_spec.rb
@@ -1,0 +1,55 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2015-16 Comcast Technology Solutions
+#
+#     Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'linux_stats'
+
+include LinuxStats::OS
+include LinuxStats::Process
+
+describe 'OS stats reporter class' do
+  it 'should use alternate paths when expected' do
+    use_alternate_paths = true
+    os_stats = LinuxStats::OS::Reporter.new(use_alternate_paths)
+    expect(os_stats.proc_directory).to eq '/hostproc'
+    expect(os_stats.sys_directory).to eq '/hostsys'
+  end
+
+  it 'should use primary paths when expected' do
+    os_stats = LinuxStats::OS::Reporter.new
+    expect(os_stats.proc_directory).to eq '/proc'
+    expect(os_stats.sys_directory).to eq '/sys'
+  end
+end
+
+describe 'Process stats reporter class' do
+  it 'should use alternate proc path when expected' do
+    use_alternate_paths = true
+    process_stats = LinuxStats::Process::Reporter.new(use_alternate_paths)
+    expect(process_stats.proc_directory).to eq '/hostproc'
+  end
+
+  it 'should use primary proc path when expected' do
+    process_stats = LinuxStats::Process::Reporter.new
+    expect(process_stats.proc_directory).to eq '/proc'
+  end
+
+end

--- a/spec/block_spec.rb
+++ b/spec/block_spec.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/block_spec.rb
+++ b/spec/block_spec.rb
@@ -73,7 +73,8 @@ METRICS_LIST = [
 describe 'watched disks' do
 
   it 'should reject block devices that have no stat file' do
-    disks = BlockIO.watched_disks DATA
+    diskreporter = Block.Reporter.new
+    disks = diskreporter.watched_disks DATA
     expect(disks.include? 'sda').to be true
     expect(disks.include? 'sdx').to be false
   end

--- a/spec/block_spec.rb
+++ b/spec/block_spec.rb
@@ -73,7 +73,7 @@ METRICS_LIST = [
 describe 'watched disks' do
 
   it 'should reject block devices that have no stat file' do
-    diskreporter = Block.Reporter.new
+    diskreporter = BlockIO::Reporter.new
     disks = diskreporter.watched_disks DATA
     expect(disks.include? 'sda').to be true
     expect(disks.include? 'sdx').to be false

--- a/spec/cpu_stat_spec.rb
+++ b/spec/cpu_stat_spec.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/disk_stat_spec.rb
+++ b/spec/disk_stat_spec.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/file_descriptor_spec.rb
+++ b/spec/file_descriptor_spec.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/loadavg_spec.rb
+++ b/spec/loadavg_spec.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/meminfo_spec.rb
+++ b/spec/meminfo_spec.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/mounts_spec.rb
+++ b/spec/mounts_spec.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/net_bandwidth_spec.rb
+++ b/spec/net_bandwidth_spec.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/net_socket_spec.rb
+++ b/spec/net_socket_spec.rb
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/process_stat_spec.rb
+++ b/spec/process_stat_spec.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spec/vmstat_spec.rb
+++ b/spec/vmstat_spec.rb
@@ -1,7 +1,7 @@
 
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 ThePlatform for Media
+# Copyright (c) 2015-16 Comcast Technology Solutions
 #
 #     Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This includes changes to allow LinuxStats to, by convention, read alternate mounted /proc and /sys directories from which to grab its stats.  These are not made configurable, and are /hostproc and /hostsys.

BlockIO methods required some major refactoring to enable this.
