### PR TITLE
SENSU-747 Adding new convention to allow reporting of host mounts wit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ linux_stats was written specifically targeting Centos 5 & 6.  It's likely
 to work on other platforms as well, but those configurations are untested.
 
 ## Docker Support
-We've added convention-based support for linux_stats to collect host information while running within a Docker
-container.  This is accomplished by mounting the host's /proc and /sys to /hostproc and /hostsys within the container.
+We've added convention-based support for linux_stats to collect host information while running 
+within a Docker container.  This is accomplished by mounting the host's /proc and /sys to 
+/hostproc and /hostsys within the container, as well as mounting the host's root filesystem ('/') to 
+/hostfs within the container.
 
 ### Note
 Mac OS X is not supported.  linux_stats gets its data by inspecting the

--- a/lib/linux_stats/os/proc_mounts.rb
+++ b/lib/linux_stats/os/proc_mounts.rb
@@ -65,9 +65,14 @@ module LinuxStats::OS::Mounts
     def report
       # execution time: 0.3 ms  [LOW]
       storage_report = {}
-      mounted_partitions.each do |partition|
-        usage = partition_used(partition)
 
+      mounted_partitions.each do |partition|
+        if (@proc_data_source.include? 'hostproc') && (!partition.include? @container_prefix)
+          partition.sub! /^\//,"/#{@container_prefix}/"
+          partition.sub! '//','/'
+        end
+
+        usage = partition_used(partition)
         # When reporting, we want the mounts to appear as if they are from the host, not the
         # container in which linux_stats is running.  The '//' case is a bit sloppy, but it's to
         # handle '/' properly.

--- a/lib/linux_stats/os/proc_mounts.rb
+++ b/lib/linux_stats/os/proc_mounts.rb
@@ -159,8 +159,8 @@ module LinuxStats::OS::Mounts
         mount_list
     end
 
-    def verify_mount_count(mount_list = nil)
-      @mount_list_size = mount_list.size
+    def verify_mount_count
+      @mount_list_size = @mounted_partitions
     end
 
   end

--- a/lib/linux_stats/os/proc_mounts.rb
+++ b/lib/linux_stats/os/proc_mounts.rb
@@ -27,10 +27,15 @@ require 'linux_stats'
 module LinuxStats::OS::Mounts
   IGNORE_PARTITIONS = [
       'docker',
+      '\/dev\/pts',
       '^\/proc',
       '^\/run',
       '^\/sys',
       '^\/cgroup',
+      '^\/hostfs\/proc',
+      '^\/hostfs\/run',
+      '^\/hostfs\/sys',
+      '^\/hostfs\/cgroup',
       '\['
   ]
   PROC_DIRECTORY_DEFAULT = '/proc'
@@ -67,6 +72,9 @@ module LinuxStats::OS::Mounts
       storage_report = {}
 
       mounted_partitions.each do |partition|
+        # Because of the way this runs on successive iterations (via the binary or within a Ruby
+        # process using this as a library), we need to manually re-build the host path when
+        # operating against data using when he are operating in the defined container mode.
         if (@proc_data_source.include? 'hostproc') && (!partition.include? @container_prefix)
           partition.sub! /^\//,"/#{@container_prefix}/"
           partition.sub! '//','/'

--- a/lib/linux_stats/version.rb
+++ b/lib/linux_stats/version.rb
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 
 module LinuxStats
-  VERSION = '0.4.0'
+  VERSION = '0.4.4'
 end
 
 module LinuxStats

--- a/spec/mounts_spec.rb
+++ b/spec/mounts_spec.rb
@@ -25,6 +25,82 @@ require 'linux_stats'
 
 include LinuxStats::OS
 
+CONTAINER_MOUNT_DATA = '
+rootfs / rootfs rw 0 0
+/dev/mapper/docker-253:4-40803-7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717 / ext4 rw,relatime,barrier=1,stripe=16,data=ordered,discard 0 0
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+tmpfs /dev tmpfs rw,nosuid,mode=755 0 0
+devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666 0 0
+shm /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=65536k 0 0
+mqueue /dev/mqueue mqueue rw,nosuid,nodev,noexec,relatime 0 0
+sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+/dev/mapper/sysdisk-rootvol /etc/sensu ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-rootvol /hostfs ext3 ro,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+devtmpfs /hostfs/dev devtmpfs rw,relatime,size=1948620k,nr_inodes=487155,mode=755 0 0
+devpts /hostfs/dev/pts devpts rw,relatime,gid=5,mode=620,ptmxmode=000 0 0
+tmpfs /hostfs/dev/shm tmpfs rw,relatime 0 0
+proc /hostfs/proc proc rw,relatime 0 0
+/proc/bus/usb /hostfs/proc/bus/usb usbfs rw,relatime 0 0
+none /hostfs/proc/sys/fs/binfmt_misc binfmt_misc rw,relatime 0 0
+sysfs /hostfs/sys sysfs rw,relatime 0 0
+/dev/mapper/sysdisk-appvol /hostfs/app ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/sda1 /hostfs/boot ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-homevol /hostfs/home ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-tmpvol /hostfs/tmp ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-varvol /hostfs/var ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/logdisk-logvol /hostfs/var/log ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-varvol /hostfs/var/lib/docker/devicemapper ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/docker-253:4-40803-7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717 /hostfs/var/lib/docker/devicemapper/mnt/7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717 ext4 rw,relatime,barrier=1,stripe=16,data=ordered,discard 0 0
+proc /hostfs/var/lib/docker/devicemapper/mnt/7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717/rootfs/proc proc rw,nosuid,nodev,noexec,relatime 0 0
+tmpfs /hostfs/var/lib/docker/devicemapper/mnt/7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717/rootfs/dev tmpfs rw,nosuid,mode=755 0 0
+devpts /hostfs/var/lib/docker/devicemapper/mnt/7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717/rootfs/dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666 0 0
+shm /hostfs/var/lib/docker/devicemapper/mnt/7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717/rootfs/dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=65536k 0 0
+mqueue /hostfs/var/lib/docker/devicemapper/mnt/7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717/rootfs/dev/mqueue mqueue rw,nosuid,nodev,noexec,relatime 0 0
+sysfs /hostfs/var/lib/docker/devicemapper/mnt/7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717/rootfs/sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
+/dev/mapper/sysdisk-rootvol /hostfs/var/lib/docker/devicemapper/mnt/7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717/rootfs/etc/hostMetadata.json ext3 ro,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-rootvol /hostfs/var/lib/docker/devicemapper/mnt/7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717/rootfs/etc/localtime ext3 ro,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-rootvol /hostfs/var/lib/docker/devicemapper/mnt/7fab58c8f0098a1976376c5271ed6540d2edeb636d831db1e6bbe4bfcc266717/rootfs/etc/sensu ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+cgroup /hostfs/cgroup/blkio cgroup rw,relatime,blkio 0 0
+proc /hostproc proc ro,relatime 0 0
+/proc/bus/usb /hostproc/bus/usb usbfs rw,relatime 0 0
+none /hostproc/sys/fs/binfmt_misc binfmt_misc rw,relatime 0 0
+sysfs /hostsys sysfs ro,relatime 0 0
+/dev/mapper/sysdisk-rootvol /opt/pl_sensu ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/logdisk-logvol /var/log/app ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-varvol /etc/resolv.conf ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+'
+
+# mount_list_size =
+RAW_HOST_MOUNT_DATA = '
+rootfs / rootfs rw 0 0
+proc /proc proc rw,relatime 0 0
+sysfs /sys sysfs rw,relatime 0 0
+devtmpfs /dev devtmpfs rw,relatime,size=1948620k,nr_inodes=487155,mode=755 0 0
+devpts /dev/pts devpts rw,relatime,gid=5,mode=620,ptmxmode=000 0 0
+tmpfs /dev/shm tmpfs rw,relatime 0 0
+/dev/mapper/sysdisk-rootvol / ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/proc/bus/usb /proc/bus/usb usbfs rw,relatime 0 0
+/dev/mapper/sysdisk-appvol /app ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/sda1 /boot ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-homevol /home ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-tmpvol /tmp ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/sysdisk-varvol /var ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+/dev/mapper/logdisk-logvol /var/log ext3 rw,relatime,errors=continue,user_xattr,acl,barrier=1,data=ordered 0 0
+none /proc/sys/fs/binfmt_misc binfmt_misc rw,relatime 0 0
+cgroup /cgroup/cpuset cgroup rw,relatime,cpuset 0 0
+cgroup /cgroup/cpu cgroup rw,relatime,cpu 0 0
+cgroup /cgroup/cpuacct cgroup rw,relatime,cpuacct 0 0
+cgroup /cgroup/memory cgroup rw,relatime,memory 0 0
+cgroup /cgroup/devices cgroup rw,relatime,devices 0 0
+cgroup /cgroup/freezer cgroup rw,relatime,freezer 0 0
+cgroup /cgroup/net_cls cgroup rw,relatime,net_cls 0 0
+cgroup /cgroup/blkio cgroup rw,relatime,blkio 0 0
+'
+
+PROC_DIRECTORY_MAIN = '/proc'
+PROC_DIRECTORY_CONTAINER = '/hostproc'
+CONTAINER_MOUNT_PREFIX = 'hostfs'
+
 describe 'Partition Report' do
   it 'SENSU-261 -- it should calculate correct disk used percent' do
     reporter = Mounts::Reporter.new
@@ -42,5 +118,13 @@ describe 'module functions' do
     reporter = Mounts::Reporter.new
     data = reporter.report
     expect(data.key? '/').to be true
+  end
+end
+
+describe 'alternate paths tests' do
+  it 'should produce a list with the right number of mounts when not in a container' do
+    reporter = Mounts::Reporter.new(PROC_DIRECTORY_MAIN, CONTAINER_MOUNT_PREFIX, RAW_HOST_MOUNT_DATA,
+                                    test_mode = true)
+    expect(reporter.mount_list_size).to be 50
   end
 end


### PR DESCRIPTION
…hin container properly.

Basically, we need to have users mount host '/' to /hostfs within the container (read-only is fine).  This way, /hostproc/mounts lists all the actual host mounts in a predictable way, prefixed by '/hostfs'.

When reporting, we remove /hostfs, so we are reporting as if the drives are being monitored on the host rather than the container guest.